### PR TITLE
Fix #43 - build: new option '--single'

### DIFF
--- a/lib/bento/build.rb
+++ b/lib/bento/build.rb
@@ -7,7 +7,7 @@ class BuildRunner
   include Common
   include PackerExec
 
-  attr_reader :template_files, :config, :dry_run, :debug, :only, :except, :mirror, :headed,
+  attr_reader :template_files, :config, :dry_run, :debug, :only, :except, :mirror, :headed, :single,
               :override_version, :build_timestamp, :cpus, :mem
 
   def initialize(opts)
@@ -19,6 +19,7 @@ class BuildRunner
     @except = opts.except
     @mirror = opts.mirror
     @headed = opts.headed ||= false
+    @single = opts.single ||= false
     @override_version = opts.override_version
     @build_timestamp = Time.now.gmtime.strftime("%Y%m%d%H%M%S")
     @cpus = opts.cpus
@@ -67,6 +68,7 @@ class BuildRunner
     cmd.insert(2, "-var") if mirror
     cmd.insert(2, "headless=true") unless headed
     cmd.insert(2, "-var") unless headed
+    cmd.insert(2, "-parallel=false") if single
     cmd.insert(2, "-debug") if debug
     cmd.insert(0, "echo") if dry_run
     cmd

--- a/lib/bento/cli.rb
+++ b/lib/bento/cli.rb
@@ -106,6 +106,10 @@ class Options
             options.headed = opt
           end
 
+          opts.on("-S", "--single", "Disable parallelization of Packer builds") do |opt|
+            options.single = opt
+          end
+
           opts.on("-v VERSION", "--version VERSION", "Override the version set in the template") do |opt|
             options.override_version = opt
           end


### PR DESCRIPTION
Disable parallelization of Packer builds.

Signed-off-by: Stephan Linz <linz@li-pro.net>